### PR TITLE
Convert to php

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,9 @@
-{ "presets": [ "es2015" ] }
+{
+  "presets": [
+    [ "es2015", { "modules": false } ],
+    "stage-1"
+  ],
+  "plugins": [
+    [ "transform-react-jsx", { "pragma":"preact.h" } ]
+  ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,83 @@
+{
+  "extends": [
+    "standard"
+  ],
+  "parser": "babel-eslint",
+  "plugins": [ "react" ],
+  "parserOptions": {
+    "ecmaVersion": 7,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "jsx": true,
+      "experimentalObjectRestSpread": true
+    }
+  },
+  "rules": {
+    "arrow-parens": [0, "as-needed"],
+    "comma-dangle": 0,
+    "generator-star-spacing": ["error", "after"],
+    "yield-star-spacing": ["error", "after"],
+    "no-cond-assign": 0,
+    "no-console": 1,
+    "operator-linebreak": 0,
+    "quote-props": [2, "as-needed", {
+      "unnecessary": false
+    }],
+    "jsx-quotes": [2, "prefer-double"],
+    "no-var": "error",
+    "prefer-const": ["error", {
+      "destructuring": "any",
+      "ignoreReadBeforeAssign": true
+    }],
+    "react/jsx-curly-spacing": [0, "always"],
+    "react/jsx-indent": [2, 2],
+    "react/jsx-indent-props": [2, 2],
+    "react/jsx-no-undef": 2,
+    "react/jsx-quotes": 0,
+    "react/jsx-uses-react": 1,
+    "react/no-unknown-property": 2,
+    "react/jsx-uses-vars": 1,
+    "react/jsx-wrap-multilines": 1,
+    "object-curly-spacing": ["error", "always"],
+    "react/sort-comp": [2, {
+      "order": [
+        "static-methods",
+        "lifecycle",
+        "render",
+        "everything-else"
+      ],
+      "groups": {
+        "lifecycle": [
+          "displayName",
+          "propTypes",
+          "contextTypes",
+          "childContextTypes",
+          "state",
+          "statics",
+          "constructor",
+          "defaultProps",
+          "getDefaultProps",
+          "getInitialState",
+          "getChildContext",
+          "componentWillMount",
+          "componentDidMount",
+          "componentWillReceiveProps",
+          "shouldComponentUpdate",
+          "componentWillUpdate",
+          "componentDidUpdate",
+          "componentWillUnmount",
+          "mixins"
+        ]
+      }
+    }]
+  },
+  "env": {
+    "amd": true,
+    "browser": true,
+    "es6": true,
+    "mocha": true,
+    "node": true,
+    "jest": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Yuge Regrets
 
-## TODO
+## Contributing
 
-- [x] remove TODO from readme and make a kanban board on GH
+**Installing**
+```sh
+$ npm i
+```
+
+**Running**
+```sh
+$ npm run dev
+```

--- a/data/twitter_config.js
+++ b/data/twitter_config.js
@@ -1,7 +1,7 @@
 module.exports = {
-    "consumerKey": "fD4GF1zWhdmgxrRnRSi3R4Tfo",
-    "consumerSecret": "CILjXY3h2o16OzNNAqqlLja0jx1Ps4nfkhJFhH5y24d2Xfbfqd",
-    "accessToken": "862420878-dbz0dyCPmLB96camnR8IujA00LH61uaj8RNCIBVO",
-    "accessTokenSecret": "qAXXiiLxehwI6R3DgK1SvGqmzDbz9HWd2hm0orYMzQVLn",
-    "callBackUrl": "http://www.localhost:8080/"
+  "consumerKey": "fD4GF1zWhdmgxrRnRSi3R4Tfo",
+  "consumerSecret": "CILjXY3h2o16OzNNAqqlLja0jx1Ps4nfkhJFhH5y24d2Xfbfqd",
+  "accessToken": "862420878-dbz0dyCPmLB96camnR8IujA00LH61uaj8RNCIBVO",
+  "accessTokenSecret": "qAXXiiLxehwI6R3DgK1SvGqmzDbz9HWd2hm0orYMzQVLn",
+  "callBackUrl": "http://www.localhost:8080/"
 }

--- a/package.json
+++ b/package.json
@@ -5,19 +5,21 @@
   "main": "app.js",
   "scripts": {
     "start": "npm run build && node server.js",
-    "build": "webpack --config webpack.config.js -p",
-    "dev": "webpack-dev-server --config webpack.config.js --inline",
+    "build": "webpack -p",
+    "dev": "node server.js & webpack --progress --colors --watch --devtool inline-source-map",
     "test": "node server.js",
     "heroku-postbuild": "webpack -p --config ./webpack.config.js --progress"
   },
   "author": "Eric Moore",
   "license": "ISC",
   "dependencies": {
+    "array-shuffle": "^1.0.1",
     "babel-cli": "^6.22.2",
     "babel-core": "^6.7.2",
-    "babel-eslint": "^6.1.0",
     "babel-loader": "^6.2.10",
+    "babel-plugin-transform-react-jsx": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
+    "babel-preset-stage-1": "^6.22.0",
     "bootstrap": "^3.3.6",
     "css-loader": "^0.23.1",
     "express": "^4.14.1",
@@ -30,6 +32,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "postcss-loader": "^1.2.2",
+    "preact": "^7.1.0",
     "require": "^2.4.20",
     "style-loader": "^0.13.0",
     "stylus": "^0.54.5",
@@ -38,6 +41,16 @@
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^1.14.1"
+  },
+  "devDependencies": {
+    "babel-eslint": "^7.0.0",
+    "eslint": "^3.13.1",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-config-standard-jsx": "^3.2.0",
+    "eslint-plugin-jsx-a11y": "^3.0.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-react": "^6.9.0",
+    "eslint-plugin-standard": "^2.0.0"
   },
   "engine": {
     "node": ">=4.3.2"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "moment": "^2.17.1",
     "postcss-loader": "^1.2.2",
     "preact": "^7.1.0",
+    "preact-css-transition-group": "^1.1.1",
     "require": "^2.4.20",
     "style-loader": "^0.13.0",
     "stylus": "^0.54.5",

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,8 @@ const sanitizeSpeech = text => text
 
 const speakIntro = () => speak("And now, 'yuuj' regrets. By remorseful Trump voters.")
 
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 const speak = text => new Promise(resolve =>
   window.responsiveVoice.speak(sanitizeSpeech(text), 'US English Male', { rate: 0.75, pitch: 0.8, onend: resolve })
 )
@@ -50,9 +52,11 @@ class Tweet extends Component {
     const { text, author } = this.props
 
     return (
-      <div className="tweet-container scroll-up">
-        <p className="tweet">{ text }</p>
-        <p className="author">{ author }</p>
+      <div className="tweet-border">
+        <div className="tweet-container">
+          <p className="tweet">{ text }</p>
+          <p className="author">{ author }</p>
+        </div>
       </div>
     )
   }
@@ -65,13 +69,11 @@ class TweetContainer extends Component {
     const videoSource = `/video/${videoID}.webm`
 
     return (
-      <div id="ragrats" className="fullscreen fade-appear">
-        <div id="tweet-border">
-          { children }
-        </div>
+      <div className="fullscreen fade-appear ragrats">
+        { children }
 
         { showACLUMessage && (
-          <div id="donate" className="fade-appear">
+          <div className="donate fade-appear">
             <p>
               Make you feel bad? You're probably a good person. <a href="https://action.aclu.org/secure/donate-to-aclu" target="_blank">Donate to the ACLU here.</a>
             </p>
@@ -115,7 +117,10 @@ class Main extends Component {
     ])
       .then(([ tweets ]) => tweets.reduce((prom, tweet, index) => prom.then(() => {
         this.setState({ tweet, index })
-        return speak(tweet.full_text)
+        return Promise.all([
+          speak(tweet.full_text),
+          delay(11000) // scroll transition minus fade transition
+        ])
       }), Promise.resolve()))
       .then(() => alert('done!'))
   }
@@ -126,10 +131,12 @@ class Main extends Component {
       <CSSTransitionGroup transitionName="fade">
         { tweet ? (
           <TweetContainer showACLUMessage={ index > 2 } key="tweets">
-            <Tweet text={ tweet.full_text } author={ tweet.user.screen_name } key={ index } />
+            <CSSTransitionGroup transitionName="fade">
+              <Tweet text={ tweet.full_text } author={ tweet.user.screen_name } key={ index } />
+            </CSSTransitionGroup>
           </TweetContainer>
         ) : (
-          <Intro key="intro"/>
+          <Intro key="intro" />
         ) }
       </CSSTransitionGroup>
     )

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import './css/main.styl'
 import preact, { render, Component } from 'preact' // eslint-disable-line
 import shuffle from 'array-shuffle'
+import CSSTransitionGroup from 'preact-css-transition-group'
 
 const blackList = ['great', 'proud', ' happy', 'thanks', 'thank you', 'courage', 'courageous', '…', '...', 'http', 'https', 'www', 'appreciate', 'god']
 
@@ -64,13 +65,13 @@ class TweetContainer extends Component {
     const videoSource = `/video/${videoID}.webm`
 
     return (
-      <div id="ragrats" className="fullscreen fade-in">
+      <div id="ragrats" className="fullscreen fade-appear">
         <div id="tweet-border">
           { children }
         </div>
 
         { showACLUMessage && (
-          <div id="donate" className="fade-in">
+          <div id="donate" className="fade-appear">
             <p>
               Make you feel bad? You're probably a good person. <a href="https://action.aclu.org/secure/donate-to-aclu" target="_blank">Donate to the ACLU here.</a>
             </p>
@@ -86,7 +87,7 @@ class TweetContainer extends Component {
 class Intro extends Component {
   render () {
     return (
-      <div className="container title-container fade-in">
+      <div className="container title-container fade-appear">
         <div className="content">
           <div className="col-xs-6">
             <p className="title">
@@ -121,16 +122,17 @@ class Main extends Component {
 
   render () {
     const { tweet, index } = this.state
-
-    if (!tweet) {
-      return <Intro />
-    } else {
-      return (
-        <TweetContainer showACLUMessage={ index > 2 }>
-          <Tweet text={ tweet.full_text } author={ tweet.user.screen_name } key={ index } />
-        </TweetContainer>
-      )
-    }
+    return (
+      <CSSTransitionGroup transitionName="fade">
+        { tweet ? (
+          <TweetContainer showACLUMessage={ index > 2 } key="tweets">
+            <Tweet text={ tweet.full_text } author={ tweet.user.screen_name } key={ index } />
+          </TweetContainer>
+        ) : (
+          <Intro key="intro"/>
+        ) }
+      </CSSTransitionGroup>
+    )
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -57,10 +57,12 @@ class Tweet extends Component {
     const videoSource = `/video/${videoID}.webm`
 
     return (
-      <div className="tweet-border">
-        <div className="tweet-container">
-          <p className="tweet">{ text }</p>
-          <p className="author">{ author }</p>
+      <div className="tweet">
+        <div className="tweet__container">
+          <div className="tweet__body">
+            <p className="tweet__text">{ text }</p>
+            <p className="tweet__author">{ author }</p>
+          </div>
         </div>
 
         <video src={ videoSource } key={ videoSource } className="fullscreen-video" autoPlay loop muted />
@@ -78,11 +80,9 @@ class TweetContainer extends Component {
         { children }
 
         { showACLUMessage && (
-          <div className="donate fade-appear">
-            <p>
-              Make you feel bad? You're probably a good person. <a href="https://action.aclu.org/secure/donate-to-aclu" target="_blank">Donate to the ACLU here.</a>
-            </p>
-          </div>
+          <p className="donate fade-appear">
+            Make you feel bad? You're probably a good person. <a href="https://action.aclu.org/secure/donate-to-aclu" target="_blank">Donate to the ACLU here.</a>
+          </p>
         ) }
       </div>
     )

--- a/src/app.js
+++ b/src/app.js
@@ -48,8 +48,13 @@ const getTweets = () => fetchTweets()
   )
 
 class Tweet extends Component {
+  state = { videoID: Math.floor(Math.random() * 18) + 1 }
+
   render () {
     const { text, author } = this.props
+    const { videoID } = this.state
+
+    const videoSource = `/video/${videoID}.webm`
 
     return (
       <div className="tweet-border">
@@ -57,6 +62,8 @@ class Tweet extends Component {
           <p className="tweet">{ text }</p>
           <p className="author">{ author }</p>
         </div>
+
+        <video src={ videoSource } key={ videoSource } className="fullscreen-video" autoPlay loop muted />
       </div>
     )
   }
@@ -65,8 +72,6 @@ class Tweet extends Component {
 class TweetContainer extends Component {
   render () {
     const { children, showACLUMessage } = this.props
-    const videoID = Math.floor(Math.random() * 18) + 1
-    const videoSource = `/video/${videoID}.webm`
 
     return (
       <div className="fullscreen fade-appear ragrats">
@@ -79,8 +84,6 @@ class TweetContainer extends Component {
             </p>
           </div>
         ) }
-
-        <video src={ videoSource } key={ videoSource } className="fullscreen-video" autoPlay loop muted />
       </div>
     )
   }

--- a/src/app.js
+++ b/src/app.js
@@ -1,72 +1,139 @@
 import './css/main.styl'
+import preact, { render, Component } from 'preact' // eslint-disable-line
+import shuffle from 'array-shuffle'
 
-var blackList = ["great", "proud", " happy", "thanks", "thank you", "courage", "courageous", "…", "...", "http", "https", "www", "appreciate", "god"]
-var tweets = []
-var writtenTweet = ""
+const blackList = ['great', 'proud', ' happy', 'thanks', 'thank you', 'courage', 'courageous', '…', '...', 'http', 'https', 'www', 'appreciate', 'god']
 
-function loadTweet() {
-  $('#title').removeClass("fade-in")
-  $('#title').addClass("fade-out")
-  setTimeout(function(){
-    var randStatus = tweets[Math.floor(Math.random() * tweets.length)]
-    writtenTweet = randStatus.full_text.replace(/RT @.+?:/g, '')
-    $("#tweet").text(writtenTweet)
-    $("#author").text("-" + randStatus.user.screen_name)
-    $('#ragrats').addClass("fade-in")
-    $("#tweet-container").addClass("scroll-up")
-    $("#donate").addClass("fade-in")
-    speakTweet(writtenTweet)
-  }, 3000)
-}
+const sanitizeSpeech = text => text
+  .replace(/^[^0-9a-z]/gi, '')
+  .replace('@realDonaldTrump', 'At Real Donald Trump')
 
-function speakTweet(writtenTweet) {
-  var spokenTweet = writtenTweet.replace(/^[^0-9a-z]/gi, '').replace('&amp;','and').replace("@realDonaldTrump", "At Real Donald Trump");
-  responsiveVoice.speak(spokenTweet, "US English Male", { rate: .75, pitch: .8})
-}
+const speakIntro = () => speak("And now, 'yuuj' regrets. By remorseful Trump voters.")
 
-function speakIntro() {
-  responsiveVoice.speak("And now, 'yuuj' regrets. By remorseful Trump voters.", "US English Male", { rate: .75, pitch: .8, onend: loadTweet})
-}
+const speak = text => new Promise(resolve =>
+  window.responsiveVoice.speak(sanitizeSpeech(text), 'US English Male', { rate: 0.75, pitch: 0.8, onend: resolve })
+)
 
-function filterTweets() {
-  tweets.forEach(function(tweet, idx){
-    blackList.forEach(function(filter){
-      if (tweet.full_text.toLowerCase().indexOf(filter) > -1) {
-        tweets.splice(idx, 1)
+const filterTweets = tweets => tweets.filter(tweet => blackList.every(filter =>
+  !tweet.full_text.toLowerCase().includes(filter)
+))
+
+const fetchTweets = () => new Promise((resolve, reject) => {
+  const request = new XMLHttpRequest()
+  request.open('GET', '/tweets', true)
+
+  request.onload = function () {
+    try {
+      if (request.status >= 200 && request.status < 400) {
+        resolve(JSON.parse(request.responseText))
       }
-    })
-  })
+    } catch (e) {}
+    reject(request)
+  }
+
+  request.onerror = () => reject(request)
+
+  request.send()
+})
+
+const getTweets = () => fetchTweets()
+  .then(msg =>
+    shuffle(filterTweets(msg.statuses)).map(tweet => ({
+      ...tweet,
+      full_text: tweet.full_text.replace(/RT @.+?:/g, '').replace('&amp;', '&')
+    }))
+  )
+
+class Tweet extends Component {
+  render () {
+    const { text, author } = this.props
+
+    return (
+      <div className="tweet-container scroll-up">
+        <p className="tweet">{ text }</p>
+        <p className="author">{ author }</p>
+      </div>
+    )
+  }
 }
 
-function loadVideo() {
-  var num = Math.floor(Math.random() * 18) + 1
-  var sourceUrl = "./video/" + num + ".webm"
-  var video = document.getElementById("video")
-  video.src = sourceUrl
-  video.load()
+class TweetContainer extends Component {
+  render () {
+    const { children, showACLUMessage } = this.props
+    const videoID = Math.floor(Math.random() * 18) + 1
+    const videoSource = `/video/${videoID}.webm`
+
+    return (
+      <div id="ragrats" className="fullscreen fade-in">
+        <div id="tweet-border">
+          { children }
+        </div>
+
+        { showACLUMessage && (
+          <div id="donate" className="fade-in">
+            <p>
+              Make you feel bad? You're probably a good person. <a href="https://action.aclu.org/secure/donate-to-aclu" target="_blank">Donate to the ACLU here.</a>
+            </p>
+          </div>
+        ) }
+
+        <video src={ videoSource } key={ videoSource } className="fullscreen-video" autoPlay loop muted />
+      </div>
+    )
+  }
 }
 
-if (typeof window !== "undefined") {
-  loadVideo()
+class Intro extends Component {
+  render () {
+    return (
+      <div className="container title-container fade-in">
+        <div className="content">
+          <div className="col-xs-6">
+            <p className="title">
+              Yuge <br/>
+              Regrets
+            </p>
+          </div>
+          <div className="col-xs-6">
+            <p className="title-author">
+              by <br/>
+              REMORSEFUL TRUMP VOTERS
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
 
-  $(window).load(function(){
-    $.ajax({
-        type: 'GET',
-        dataType: 'json',
-        data: {},
-        url: "/tweets",
-        error: function (jqXHR, textStatus, errorThrown) {
-            console.log(jqXHR)
-        },
-        success: function (msg) {
-            tweets = msg.statuses
-            filterTweets()
-        }
-    });
-
-    setTimeout(function(){
+class Main extends Component {
+  componentDidMount () {
+    Promise.all([
+      getTweets(),
       speakIntro()
-      // loadTweet()
-    }, 1500)
-  })
+    ])
+      .then(([ tweets ]) => tweets.reduce((prom, tweet, index) => prom.then(() => {
+        this.setState({ tweet, index })
+        return speak(tweet.full_text)
+      }), Promise.resolve()))
+      .then(() => alert('done!'))
+  }
+
+  render () {
+    const { tweet, index } = this.state
+
+    if (!tweet) {
+      return <Intro />
+    } else {
+      return (
+        <TweetContainer showACLUMessage={ index > 2 }>
+          <Tweet text={ tweet.full_text } author={ tweet.user.screen_name } key={ index } />
+        </TweetContainer>
+      )
+    }
+  }
 }
+
+window.responsiveVoice.addEventListener('OnReady', () => {
+  render(<Main />, document.getElementById('app'))
+})

--- a/src/css/main.styl
+++ b/src/css/main.styl
@@ -114,11 +114,11 @@ a:focus
   min-height 100%
   z-index: -1
 
-.fade-in
+.fade-enter, .fade-appear
   animation fadein 4s
   animation-fill-mode forwards
 
-.fade-out
+.fade-leave
   animation fadeout 4s
   animation-fill-mode forwards
 

--- a/src/css/main.styl
+++ b/src/css/main.styl
@@ -1,3 +1,5 @@
+link-blue = #7bc5d1
+
 @keyframes fadein
   from
     opacity 0
@@ -12,9 +14,9 @@
 
 @keyframes scrollup
   from
-    top 100%
+    transform translateY(100%)
   to
-    top -200%
+    transform translateY(-100%)
 
 html, body
   height 100%
@@ -28,7 +30,7 @@ html, body
   background-color black
 
 a
-  color #7bc5d1
+  color link-blue
 
 a:hover
   color #75b0ba
@@ -36,7 +38,7 @@ a:hover
   text-decoration none
 
 a:focus
-  color #7bc5d1
+  color link-blue
   text-decoration none
 
 #app
@@ -44,7 +46,7 @@ a:focus
   height 100%
 
 .title-container
-  background url(../img/title.jpg) #7bc5d1
+  background url(../img/title.jpg) link-blue
   background-size cover
 
 .container
@@ -60,42 +62,31 @@ a:focus
   display block
   text-align center
 
-#ragrats
+.ragrats
   opacity 0
   display flex
-  display -webkit-flex
   align-items center
   justify-content center
 
-#tweet-border
-  display flex
-  align-items center
-  justify-content center
+.tweet-border
   overflow hidden
   position fixed
-  top 50px
+  top 0
   left 0
   right 0
-  bottom 50px
-
-  &:before, &:after
-    content ""
-    position absolute
-    left 0
-    right 0
+  bottom 0
 
 .tweet-container
   width 70%
+  left 15%
   font-size 1.8em
-  top 100%
+  height 100%
   position relative
+  transform translateY(-100%)
+  animation scrollup 15s linear
 
 .author
   text-align right
-
-.scroll-up
-  animation scrollup 30s
-  animation-fill-mode forwards
 
 .fullscreen
   position fixed
@@ -135,7 +126,7 @@ a:focus
   position fixed
   bottom 2%
 
-#donate
+.donate
   font-size .5em
   opacity 0
   position fixed
@@ -144,9 +135,6 @@ a:focus
   z-index 100
   padding-top 10px
   text-align center
-
-#reset
-  opacity 0
 
 #audio
   display none

--- a/src/css/main.styl
+++ b/src/css/main.styl
@@ -39,6 +39,10 @@ a:focus
   color #7bc5d1
   text-decoration none
 
+#app
+  width 100%
+  height 100%
+
 .title-container
   background url(../img/title.jpg) #7bc5d1
   background-size cover
@@ -80,13 +84,13 @@ a:focus
     left 0
     right 0
 
-#tweet-container
+.tweet-container
   width 70%
   font-size 1.8em
   top 100%
   position relative
 
-#author
+.author
   text-align right
 
 .scroll-up
@@ -106,7 +110,9 @@ a:focus
   position absolute
   top 0
   left 0
-  width 100%
+  min-width 100%
+  min-height 100%
+  z-index: -1
 
 .fade-in
   animation fadein 4s

--- a/src/css/main.styl
+++ b/src/css/main.styl
@@ -1,4 +1,5 @@
 link-blue = #7bc5d1
+scroll-time = 15s
 
 @keyframes fadein
   from
@@ -14,7 +15,7 @@ link-blue = #7bc5d1
 
 @keyframes scrollup
   from
-    transform translateY(100%)
+    transform translateY(0%)
   to
     transform translateY(-100%)
 
@@ -68,7 +69,7 @@ a:focus
   align-items center
   justify-content center
 
-.tweet-border
+.tweet
   overflow hidden
   position fixed
   top 0
@@ -76,16 +77,23 @@ a:focus
   right 0
   bottom 0
 
-.tweet-container
+.tweet__container
   width 70%
   left 15%
-  font-size 1.8em
   height 100%
+  font-size 1.8em
   position relative
   transform translateY(-100%)
-  animation scrollup 15s linear
+  animation scrollup scroll-time linear
 
-.author
+.tweet__body {
+  position absolute
+  top 100%
+  transform translateY(-100%)
+  animation scrollup scroll-time linear
+}
+
+.tweet__author
   text-align right
 
 .fullscreen
@@ -128,13 +136,15 @@ a:focus
 
 .donate
   font-size .5em
-  opacity 0
   position fixed
   width 100%
-  bottom 0
+  top 100%
   z-index 100
-  padding-top 10px
+  padding 20px 0 10px
   text-align center
+  transform translateY(-100%)
+  background linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0) 100%)
+  animation scrollup 300ms ease-out
 
 #audio
   display none

--- a/src/index.html
+++ b/src/index.html
@@ -15,42 +15,12 @@
 </head>
 <body>
     <!-- App -->
-    <div id="title" class="container title-container fade-in">
-        <div class="content">
-            <div class="col-xs-6">
-                <p class="title">
-                    Yuge <br/>
-                    Regrets
-                </p>
-            </div>
-            <div class="col-xs-6">
-                <p class="title-author">
-                    by <br/>
-                    REMORSEFUL TRUMP VOTERS
-                </p>
-            </div>
-        </div>
-    </div>
-    <!-- TODO the scrolling text should be an anchor that links to the tweet  -->
-    <div id="ragrats" class="fullscreen">
-        <video id="video" class="fullscreen-video" autoplay loop muted>
-            <source src="" type="video/webm">
-        </video>
-        <div id="tweet-border">
-            <div id="tweet-container">
-                <p id="tweet"></p>
-                <p id="author"></p>
-            </div>
-        </div>
-    </div>
-    <div id="donate">
-        <p>
-            Make you feel bad? You're probably a good person. <a href="https://action.aclu.org/secure/donate-to-aclu" target="_blank">Donate to the ACLU here.</a>
-        </p>
-    </div>
+    <div id="app"></div>
+
     <audio id="audio" controls autoplay>
       <source src="./audio/yugeregrets.mp3" type="audio/mpeg">
     </audio>
+
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/src/index.html
+++ b/src/index.html
@@ -31,8 +31,6 @@
       ga('send', 'pageview');
     </script>
     <script src="./js/responsivevoice.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <script src="./dist/main.bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
After this branch, the prod bundle has gone down from 94kb to 20kb, despite now containing all templating logic.  On top of this, was able to delete the global scripts for bootstrap and jQuery, decreasing our total page size even further.

**Goals here:** 💯
- Use Preact for DOM stuff
- Remove jQuery / Bootstrap JS (future may remove Bootstrap CSS)
- Added looping logic for tweets -- sometimes the announcer reads the tweet faster than the animation -- this may need tweaking
- Added a dev mode for Webpack, as well as source maps.  In the immortal words of Borat, "very nice!"
- Now only show ACLU link after 3rd tweet
- Added build instructions to README